### PR TITLE
Codex Cloud用setupスクリプト、イメージキャッシュ後maintenanceスクリプトを追加

### DIFF
--- a/.codex/cloud/post-cache-maintenance.sh
+++ b/.codex/cloud/post-cache-maintenance.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "$EUID" -ne 0 ]]; then
+    echo "This script must be run as root." >&2
+    exit 1
+fi
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.codex/cloud/post-cache-maintenance.sh
+++ b/.codex/cloud/post-cache-maintenance.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$PATH"
+
+curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+bash /tmp/dotnet-install.sh --channel 9.0
+bash /tmp/dotnet-install.sh --channel 8.0
+rm /tmp/dotnet-install.sh

--- a/docs/design/codex-cloud-scripts.md
+++ b/docs/design/codex-cloud-scripts.md
@@ -1,0 +1,23 @@
+Codex Cloud Setup and Maintenance Scripts
+=========================================
+
+Purpose
+- Automate .NET SDK installation on Codex Cloud workers.
+- Trim package caches after image caching to keep layers small.
+
+Scope and Boundaries
+- Setup installs .NET SDK 9.0 and 8.0 using the official installer.
+- Maintenance removes apt package lists and cache.
+- Scripts live under `.codex/cloud` and have no runtime dependency on library code.
+
+Dependencies
+- curl
+- bash
+- apt-get
+
+Test Strategy
+- Run setup and verify `dotnet --info` outputs installed SDKs.
+- Maintenance is idempotent and safe to run after caching.
+
+Migration / Compatibility
+- None.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,3 +17,4 @@ Glossary (EN → JA)
 - Triangle Indices → 三角形インデックス
 - Inverse Mass → 逆質量
 
+- Codex Cloud → Codex クラウド


### PR DESCRIPTION
## Summary
- add Codex Cloud setup script to install .NET SDKs
- add maintenance script to prune apt cache after image caching
- document Codex Cloud script design

## Testing
- `bash .codex/cloud/setup.sh` *(failed: CONNECT tunnel failed 403)*
- `apt-get update` *(failed: 403 Forbidden)*
- `dotnet format` *(failed: command not found)*
- `dotnet build -c Release --no-restore` *(failed: command not found)*
- `dotnet test -c Release --no-build --verbosity normal` *(failed: command not found)*
- `dotnet build examples/DotCloth.MonoGameSample -c Release --no-restore` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe9858e20832a821d4caca9d42182