### PR TITLE
fix(simulation): soften low-stiffness response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Testing and CI
 - Test framework: xUnit.
 - CI runs: format/lint/typecheck/test as required checks.
 - Task completion commands:
-  - `dotnet format --check`
+  - `dotnet format --verify-no-changes`
   - `dotnet build -f net9.0`
   - `dotnet test -f net9.0`
   - `dotnet build -f net8.0`

--- a/docs/design/solver-stiffness-scaling.md
+++ b/docs/design/solver-stiffness-scaling.md
@@ -9,7 +9,7 @@ Ensure solver behaviour remains predictable as stiffness values approach zero.
 
 ## Testing
 - Parameter sweep for stretch, bend, and tether across low and high values.
-- `dotnet format --check`
+- `dotnet format --verify-no-changes`
 - `dotnet build -f net9.0`
 - `dotnet test -f net9.0`
 - `dotnet build -f net8.0`

--- a/docs/design/solver-stiffness-scaling.md
+++ b/docs/design/solver-stiffness-scaling.md
@@ -1,0 +1,20 @@
+# Solver stiffness scaling
+
+## Purpose
+Ensure solver behaviour remains predictable as stiffness values approach zero.
+
+## Summary
+- Apply minimum stiffness floors when mapping to constraint softness and clamps.
+- Execute post-stabilization based on constraint presence instead of stiffness thresholds.
+
+## Testing
+- Parameter sweep for stretch, bend, and tether across low and high values.
+- `dotnet format --check`
+- `dotnet build -f net9.0`
+- `dotnet test -f net9.0`
+- `dotnet build -f net8.0`
+- `dotnet test -f net8.0`
+- `dotnet build -f net9.0 --property DotClothEnableExperimentalXpbd=true`
+- `dotnet test -f net9.0 --property DotClothEnableExperimentalXpbd=true`
+- `dotnet build -f net8.0 --property DotClothEnableExperimentalXpbd=true`
+- `dotnet test -f net8.0 --property DotClothEnableExperimentalXpbd=true`

--- a/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
+++ b/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
@@ -439,7 +439,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                     }
                 }
                 // Tethers (single-body)
-                if (_cfg.TetherStiffness > 0f || hasTether)
+                if (hasTether)
                 {
                     for (int i = 0; i < _vertexCount; i++)
                     {

--- a/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
+++ b/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
@@ -152,30 +152,22 @@ public sealed class VelocityImpulseSolver : IClothSimulator
         float betaBend = MapStiffnessToBeta(_cfg.BendStiffness, dt, iterations) * BendBetaScale * edgeScale;
         float betaTether = MathF.Min(0.75f, MapStiffnessToBeta(_cfg.TetherStiffness, dt, iterations) * 1.35f);
 
-        float stretchS = MathF.Max(_cfg.StretchStiffness, 0.05f);
-        float bendS = MathF.Max(_cfg.BendStiffness, 0.1f);
-        float tetherS = MathF.Max(_cfg.TetherStiffness, 0.05f);
+        float stretchS = _cfg.StretchStiffness <= 0f ? 0f : MathF.Max(_cfg.StretchStiffness, 0.05f);
+        float bendS = _cfg.BendStiffness <= 0f ? 0f : MathF.Max(_cfg.BendStiffness, 0.1f);
+        float tetherS = _cfg.TetherStiffness <= 0f ? 0f : MathF.Max(_cfg.TetherStiffness, 0.05f);
 
-        float cfmStretch = BaseCfmStretch / stretchS;
-        float cfmBend = BaseCfmBend / bendS / edgeScale;
-        float cfmTether = BaseCfmTether / tetherS;
+        bool hasStretch = _cfg.StretchStiffness > 0f && _edges.Length > 0;
+        bool hasBend = _cfg.BendStiffness > 0f && _bends.Length > 0;
+        bool hasTether = _cfg.TetherStiffness > 0f && _tetherAnchorIndex.Length > 0;
 
-        float lambdaClampStretch = BaseLambdaClampStretch * stretchS;
-        float lambdaClampCompress = BaseLambdaClampCompress * stretchS;
-        float lambdaClampBend = BaseLambdaClampBend * bendS;
-        float lambdaClampTether = BaseLambdaClampTether * tetherS;
+        float cfmStretch = hasStretch ? BaseCfmStretch / stretchS : 0f;
+        float cfmBend = hasBend ? BaseCfmBend / bendS / edgeScale : 0f;
+        float cfmTether = hasTether ? BaseCfmTether / tetherS : 0f;
 
-        bool hasStretch = _edges.Length > 0;
-        bool hasBend = _bends.Length > 0;
-        bool hasTether = false;
-        for (int i = 0; i < _tetherAnchorIndex.Length; i++)
-        {
-            if (_tetherAnchorIndex[i] >= 0)
-            {
-                hasTether = true;
-                break;
-            }
-        }
+        float lambdaClampStretch = hasStretch ? BaseLambdaClampStretch * stretchS : 0f;
+        float lambdaClampCompress = hasStretch ? BaseLambdaClampCompress * stretchS : 0f;
+        float lambdaClampBend = hasBend ? BaseLambdaClampBend * bendS : 0f;
+        float lambdaClampTether = hasTether ? BaseLambdaClampTether * tetherS : 0f;
 
         // Stabilizers: small CFM (softness), under-relaxation, per-iteration impulse clamp
 


### PR DESCRIPTION
## Summary
- apply minimum stiffness floors to constraint softness and clamps
- run post-stabilization based on constraint presence

## Design Summary
- [solver stiffness scaling](docs/design/solver-stiffness-scaling.md)

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`
- `dotnet build -f net9.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net9.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet build -f net8.0 --property DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net8.0 -p:DotClothEnableExperimentalXpbd=true`


------
https://chatgpt.com/codex/tasks/task_e_68bd182cb594832a8df18b9335668dc8