### PR TITLE
perf(solver): parallelize constraint loops

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -8,7 +8,7 @@ Parameter Model
 Core Interfaces
 - `IClothSimulator`
   - `void Initialize(ReadOnlySpan<Vector3> positions, ReadOnlySpan<int> triangles, ClothParameters parameters)`
-  - `void Step(float deltaTime, Span<Vector3> positions, Span<Vector3> velocities)`
+  - `void Step(float deltaTime, Vector3[] positions, Vector3[] velocities)`
   - `void UpdateParameters(ClothParameters parameters)`
   - `void SetInverseMasses(ReadOnlySpan<float> inverseMasses)` — 0 fixes a vertex (pinning)
   - `void PinVertices(ReadOnlySpan<int> indices)` — convenience pin API

--- a/docs/design/parallel-batching.md
+++ b/docs/design/parallel-batching.md
@@ -1,0 +1,21 @@
+# Parallel constraint batching
+
+## Purpose
+Speed up `VelocityImpulseSolver` by executing independent constraint batches on multiple cores.
+
+## Scope and boundary
+- Applies only to velocity-level solver loops.
+- `IClothSimulator.Step` now accepts `Vector3[]` positions/velocities so parallel loops operate in safe code.
+- Internal behavior must remain deterministic.
+
+## Placement
+- `VelocityImpulseSolver.Step` runs `Parallel.For` over tethers and each stretch/bend batch with array indexing.
+- Uses `System.Threading.Tasks`.
+
+## Test strategy
+- Existing unit tests.
+- Performance harness `perf/DotCloth.Perf` before/after.
+
+## Migration
+Breaking: `Step(float, Span<Vector3>, Span<Vector3>)` → `Step(float, Vector3[], Vector3[])`.
+Consumers passing spans must supply arrays.

--- a/src/DotCloth/Simulation/Core/PbdSolver.cs
+++ b/src/DotCloth/Simulation/Core/PbdSolver.cs
@@ -97,7 +97,7 @@ public sealed class XpbdSolver : IClothSimulator
     }
 
     /// <inheritdoc />
-    public void Step(float deltaTime, Span<Vector3> positions, Span<Vector3> velocities)
+    public void Step(float deltaTime, Vector3[] positions, Vector3[] velocities)
     {
         if (positions.Length != _vertexCount) throw new ArgumentException("positions length mismatch", nameof(positions));
         if (velocities.Length != _vertexCount) throw new ArgumentException("velocities length mismatch", nameof(velocities));

--- a/src/DotCloth/Simulation/Core/PbdSolverFacade.cs
+++ b/src/DotCloth/Simulation/Core/PbdSolverFacade.cs
@@ -31,7 +31,7 @@ public sealed class PbdSolver : IClothSimulator
         => _impl.Initialize(positions, triangles, parameters);
 
     /// <inheritdoc />
-    public void Step(float deltaTime, Span<Vector3> positions, Span<Vector3> velocities)
+    public void Step(float deltaTime, Vector3[] positions, Vector3[] velocities)
         => _impl.Step(deltaTime, positions, velocities);
 
     /// <inheritdoc />

--- a/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
+++ b/src/DotCloth/Simulation/Core/VelocityImpulseSolver.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using DotCloth.Simulation.Parameters;
 
 namespace DotCloth.Simulation.Core;
@@ -128,12 +129,13 @@ public sealed class VelocityImpulseSolver : IClothSimulator
     }
 
     /// <inheritdoc />
-    public void Step(float deltaTime, Span<Vector3> positions, Span<Vector3> velocities)
+    public void Step(float deltaTime, Vector3[] positions, Vector3[] velocities)
     {
         if (positions.Length != _vertexCount) throw new ArgumentException("positions length mismatch", nameof(positions));
         if (velocities.Length != _vertexCount) throw new ArgumentException("velocities length mismatch", nameof(velocities));
         if (deltaTime <= 0) throw new ArgumentOutOfRangeException(nameof(deltaTime));
-
+        var positionsArr = positions;
+        var velocitiesArr = velocities;
         int substeps = Math.Max(1, _cfg.Substeps);
         int iterations = Math.Max(1, _cfg.Iterations);
         float dt = deltaTime / substeps;
@@ -173,18 +175,17 @@ public sealed class VelocityImpulseSolver : IClothSimulator
 
         for (int s = 0; s < substeps; s++)
         {
-            // Save previous positions for collision sweep and velocity update
-            for (int i = 0; i < _vertexCount; i++) _prev[i] = positions[i];
+            Array.Copy(positionsArr, _prev, _vertexCount);
 
             // 1) External forces -> velocity (semi-implicit)
             for (int i = 0; i < _vertexCount; i++)
             {
                 if (_invMass[i] == 0f)
                 {
-                    velocities[i] = Vector3.Zero;
+                    velocitiesArr[i] = Vector3.Zero;
                     continue;
                 }
-                var v = velocities[i];
+                var v = velocitiesArr[i];
                 var a = accelBase;
                 if (useRandom)
                 {
@@ -193,7 +194,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                 }
                 v += a * dt;
                 v -= v * drag * dt; // simple drag
-                velocities[i] = v;
+                velocitiesArr[i] = v;
             }
 
             // 2) Constraint iterations (sequential impulses on velocity)
@@ -202,16 +203,16 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                 // Tether/Pin — solve first to let anchors dominate
                 if (hasTether)
                 {
-                    for (int i = 0; i < _vertexCount; i++)
+                    Parallel.For(0, _vertexCount, i =>
                     {
                         float wi = _invMass[i];
-                        if (wi <= 0f) continue;
+                        if (wi <= 0f) return;
                         Vector3 target;
                         float targetLen;
                         int a = _tetherAnchorIndex[i];
                         if (a >= 0)
                         {
-                            target = positions[a];
+                            target = positionsArr[a];
                             targetLen = _tetherAnchorRestLength[i];
                         }
                         else
@@ -219,36 +220,34 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                             target = _rest[i];
                             targetLen = 0f;
                         }
-                        var xi = positions[i];
+                        var xi = positionsArr[i];
                         var d = xi - target;
                         var lenSq = d.LengthSquared();
-                        if (lenSq <= 1e-18f) continue;
+                        if (lenSq <= 1e-18f) return;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
                         var len = 1f / invLen;
-                        var n = (target - xi) * invLen; // toward target
+                        var n = (target - xi) * invLen;
                         float C = len - targetLen;
-                        if (C <= 0f) continue; // inside target; do nothing
-                        float rel = Vector3.Dot(velocities[i], n); // anchor has zero velocity in constraint frame
+                        if (C <= 0f) return;
+                        float rel = Vector3.Dot(velocitiesArr[i], n);
                         float bterm = +betaTether * C / dt;
                         float w = wi;
                         float denom = w + cfmTether;
                         float lambda = -(rel + bterm) / denom;
                         lambda = MathF.Max(-lambdaClampTether, MathF.Min(lambdaClampTether, lambda));
                         var dv = (lambda * OmegaTether) * n;
-                        // Apply impulse to move toward target (sign adjusted via bterm)
-                        velocities[i] -= wi * dv;
-                        // Shock-like clamp: ensure sufficient inward velocity toward target when violating
+                        velocitiesArr[i] -= wi * dv;
                         if (C > 0f)
                         {
-                            float rel2 = Vector3.Dot(velocities[i], n); // inward component (along n)
-                            float targetRel = C / dt; // require at least this inward speed
+                            float rel2 = Vector3.Dot(velocitiesArr[i], n);
+                            float targetRel = C / dt;
                             if (rel2 < targetRel)
                             {
-                                float corr = (targetRel - rel2);
-                                velocities[i] += corr * n; // increase inward component
+                                float corr = targetRel - rel2;
+                                velocitiesArr[i] += corr * n;
                             }
                         }
-                    }
+                    });
                 }
 
                 // Stretch: edges
@@ -257,51 +256,48 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                     for (int b = 0; b < _edgeBatches.Length; b++)
                     {
                         var batch = _edgeBatches[b];
-                        for (int bi = 0; bi < batch.Length; bi++)
+                        Parallel.For(0, batch.Length, bi =>
                         {
                             int e = batch[bi];
                             ref readonly var edge = ref _edges[e];
                             int i = edge.I;
                             int j = edge.J;
-                            var xi = positions[i];
-                            var xj = positions[j];
+                            var xi = positionsArr[i];
+                            var xj = positionsArr[j];
                             var d = xj - xi;
                             var lenSq = d.LengthSquared();
-                            if (lenSq <= 1e-18f) continue;
+                            if (lenSq <= 1e-18f) return;
                             var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
                             var len = 1f / invLen;
                             var n = d * invLen;
-                            float C = len - edge.RestLength; // positional deviation
+                            float C = len - edge.RestLength;
                             float w = edge.WSum;
-                            if (w <= 0f) continue;
-                            var rel = Vector3.Dot(velocities[j] - velocities[i], n);
+                            if (w <= 0f) return;
+                            var rel = Vector3.Dot(velocitiesArr[j] - velocitiesArr[i], n);
                             if (C > 0f)
                             {
-                                float bterm = -betaStretch * C / dt; // Baumgarte stabilization
+                                float bterm = -betaStretch * C / dt;
                                 float denom = w + cfmStretch;
                                 float lambda = -(rel + bterm) / denom;
-                                // impulse clamp (tension)
                                 lambda = MathF.Max(-lambdaClampStretch, MathF.Min(lambdaClampStretch, lambda));
                                 var dv = (lambda * Omega) * n;
-                                velocities[i] -= edge.Wi * dv;
-                                velocities[j] += edge.Wj * dv;
+                                velocitiesArr[i] -= edge.Wi * dv;
+                                velocitiesArr[j] += edge.Wj * dv;
                             }
                             else if (C < 0f)
                             {
-                                // Allow anchor-pair edges to compress freely (tether should win)
                                 if (_tetherAnchorIndex[i] == j || _tetherAnchorIndex[j] == i)
-                                    continue;
+                                    return;
                                 float betaC = betaStretch * CompressBetaScale;
-                                float bterm = -betaC * C / dt; // note: C<0 → bterm reduces compression slowly
+                                float bterm = -betaC * C / dt;
                                 float denom = w + cfmStretch * CfmCompressScale;
                                 float lambda = -(rel + bterm) / denom;
-                                // tighter clamp for compression
                                 lambda = MathF.Max(-lambdaClampCompress, MathF.Min(lambdaClampCompress, lambda));
                                 var dv = (lambda * Omega) * n;
-                                velocities[i] -= edge.Wi * dv;
-                                velocities[j] += edge.Wj * dv;
+                                velocitiesArr[i] -= edge.Wi * dv;
+                                velocitiesArr[j] += edge.Wj * dv;
                             }
-                        }
+                        });
                     }
                 }
 
@@ -311,32 +307,32 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                     for (int bb = 0; bb < _bendBatches.Length; bb++)
                     {
                         var batch = _bendBatches[bb];
-                        for (int bi = 0; bi < batch.Length; bi++)
+                        Parallel.For(0, batch.Length, bi =>
                         {
                             int biIdx = batch[bi];
                             ref readonly var bend = ref _bends[biIdx];
                             int k = bend.K;
                             int l = bend.L;
-                            var xk = positions[k];
-                            var xl = positions[l];
+                            var xk = positionsArr[k];
+                            var xl = positionsArr[l];
                             var d = xl - xk;
                             var lenSq = d.LengthSquared();
-                            if (lenSq <= 1e-18f) continue;
+                            if (lenSq <= 1e-18f) return;
                             var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
                             var len = 1f / invLen;
                             var n = d * invLen;
                             float C = len - bend.RestDistance;
                             float w = bend.WSum;
-                            if (w <= 0f) continue;
-                            var rel = Vector3.Dot(velocities[l] - velocities[k], n);
+                            if (w <= 0f) return;
+                            var rel = Vector3.Dot(velocitiesArr[l] - velocitiesArr[k], n);
                             float bterm = betaBend * C / dt;
                             float denom = w + cfmBend;
                             float lambda = -(rel + bterm) / denom;
                             lambda = MathF.Max(-lambdaClampBend, MathF.Min(lambdaClampBend, lambda));
                             var dv = (lambda * Omega) * n;
-                            velocities[k] -= bend.Wk * dv;
-                            velocities[l] += bend.Wl * dv;
-                        }
+                            velocitiesArr[k] -= bend.Wk * dv;
+                            velocitiesArr[l] += bend.Wl * dv;
+                        });
                     }
                 }
             }
@@ -346,7 +342,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
             {
                 foreach (var c in _colliders)
                 {
-                    c.Resolve(_prev, positions, velocities, dt, _cfg.CollisionThickness, _cfg.Friction);
+                    c.Resolve(_prev, positionsArr, velocitiesArr, dt, _cfg.CollisionThickness, _cfg.Friction);
                 }
             }
 
@@ -356,11 +352,11 @@ public sealed class VelocityImpulseSolver : IClothSimulator
             {
                 if (_invMass[i] == 0f)
                 {
-                    velocities[i] = Vector3.Zero;
+                    velocitiesArr[i] = Vector3.Zero;
                     continue;
                 }
-                velocities[i] *= dampFactor;
-                positions[i] += velocities[i] * dt;
+                velocitiesArr[i] *= dampFactor;
+                positionsArr[i] += velocitiesArr[i] * dt;
             }
 
             // 5) Post-stabilization (position-level) — small corrective projections
@@ -376,7 +372,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         ref readonly var edge = ref _edges[e];
                         int i = edge.I;
                         int j = edge.J;
-                        var d = positions[j] - positions[i];
+                        var d = positionsArr[j] - positionsArr[i];
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -389,20 +385,18 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         {
                             float corrMag = PosAlphaStretch * C / MathF.Max(1e-8f, wsum);
                             var corr = corrMag * n;
-                            positions[i] += edge.Wi * corr;
-                            positions[j] -= edge.Wj * corr;
+                            positionsArr[i] += edge.Wi * corr;
+                            positionsArr[j] -= edge.Wj * corr;
                         }
                         else if (C < 0f)
                         {
-                            // Gentle anti-compression to prevent over-contraction drift (adaptive)
                             float rest = MathF.Max(1e-12f, edge.RestLength);
                             float ratio = len / rest;
                             float posAlphaCompress = ratio < 0.90f ? 0.40f : 0.20f;
                             float corrMag = posAlphaCompress * (-C) / MathF.Max(1e-8f, wsum);
                             var corr = corrMag * n;
-                            // Apply opposite to stretch: push apart slightly
-                            positions[i] -= edge.Wi * corr;
-                            positions[j] += edge.Wj * corr;
+                            positionsArr[i] -= edge.Wi * corr;
+                            positionsArr[j] += edge.Wj * corr;
                         }
                     }
                 }
@@ -414,7 +408,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         ref readonly var bend = ref _bends[b];
                         int k = bend.K;
                         int l = bend.L;
-                        var d = positions[l] - positions[k];
+                        var d = positionsArr[l] - positionsArr[k];
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -426,8 +420,8 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         if (wsum <= 0f) continue;
                         float corrMag = PosAlphaBend * C / MathF.Max(1e-8f, wsum);
                         var corr = corrMag * n;
-                        positions[k] += bend.Wk * corr;
-                        positions[l] -= bend.Wl * corr;
+                        positionsArr[k] += bend.Wk * corr;
+                        positionsArr[l] -= bend.Wl * corr;
                     }
                 }
                 // Tethers (single-body)
@@ -440,9 +434,9 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         Vector3 target;
                         float targetLen;
                         int a = _tetherAnchorIndex[i];
-                        if (a >= 0) { target = positions[a]; targetLen = _tetherAnchorRestLength[i]; }
+                        if (a >= 0) { target = positionsArr[a]; targetLen = _tetherAnchorRestLength[i]; }
                         else { target = _rest[i]; targetLen = 0f; }
-                        var d = positions[i] - target;
+                        var d = positionsArr[i] - target;
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -450,8 +444,8 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         float C = len - targetLen;
                         if (C <= 0f) continue;
                         var n = d * invLen;
-                        var corr = PosAlphaTether * C * n; // single-body
-                        positions[i] -= corr;
+                        var corr = PosAlphaTether * C * n;
+                        positionsArr[i] -= corr;
                     }
                 }
 
@@ -461,8 +455,8 @@ public sealed class VelocityImpulseSolver : IClothSimulator
             // Recompute velocities from positions delta to keep consistency
             for (int i = 0; i < _vertexCount; i++)
             {
-                if (_invMass[i] == 0f) { velocities[i] = Vector3.Zero; continue; }
-                velocities[i] = (positions[i] - _prev[i]) / dt;
+                if (_invMass[i] == 0f) { velocitiesArr[i] = Vector3.Zero; continue; }
+                velocitiesArr[i] = (positionsArr[i] - _prev[i]) / dt;
             }
 
 #if DOTCLOTH_ENABLE_VELOCITY_CLAMP
@@ -478,7 +472,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         ref readonly var edge = ref _edges[e];
                         int i = edge.I;
                         int j = edge.J;
-                        var d = positions[j] - positions[i];
+                        var d = positionsArr[j] - positionsArr[i];
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -486,15 +480,15 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         float strain = L / MathF.Max(1e-12f, edge.RestLength);
                         if (strain <= 1f + limit) continue;
                         var n = d * invLen;
-                        float rel = Vector3.Dot(velocities[j] - velocities[i], n);
+                        float rel = Vector3.Dot(velocitiesArr[j] - velocitiesArr[i], n);
                         float targetRel = -kClamp * (strain - (1f + limit)) / dt;
                         float corr = (rel - targetRel);
                         float w = edge.WSum;
                         if (w <= 0f) continue;
                         float lambda = corr / w;
                         var dv = lambda * n;
-                        velocities[i] += edge.Wi * dv;
-                        velocities[j] -= edge.Wj * dv;
+                        velocitiesArr[i] += edge.Wi * dv;
+                        velocitiesArr[j] -= edge.Wj * dv;
                     }
                 }
                 // Second, lighter pass to catch residual overstretch
@@ -505,7 +499,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         ref readonly var edge = ref _edges[e];
                         int i = edge.I;
                         int j = edge.J;
-                        var d = positions[j] - positions[i];
+                        var d = positionsArr[j] - positionsArr[i];
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -513,15 +507,15 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         float strain = L / MathF.Max(1e-12f, edge.RestLength);
                         if (strain <= 1f + limit) continue;
                         var n = d * invLen;
-                        float rel = Vector3.Dot(velocities[j] - velocities[i], n);
+                        float rel = Vector3.Dot(velocitiesArr[j] - velocitiesArr[i], n);
                         float targetRel = -kClamp * (strain - (1f + limit)) / dt;
                         float corr = (rel - targetRel);
                         float w = edge.WSum;
                         if (w <= 0f) continue;
                         float lambda = corr / w;
                         var dv = lambda * n;
-                        velocities[i] += edge.Wi * dv;
-                        velocities[j] -= edge.Wj * dv;
+                        velocitiesArr[i] += edge.Wi * dv;
+                        velocitiesArr[j] -= edge.Wj * dv;
                     }
                 }
                 // Compression clamp: prevent edges from collapsing far below rest
@@ -535,7 +529,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         int j = edge.J;
                         // Skip compression clamp for anchor-pair edges; tether should dominate
                         if (_tetherAnchorIndex[i] == j || _tetherAnchorIndex[j] == i) continue;
-                        var d = positions[j] - positions[i];
+                        var d = positionsArr[j] - positionsArr[i];
                         var lenSq = d.LengthSquared();
                         if (lenSq <= 1e-18f) continue;
                         var invLen = MathF.ReciprocalSqrtEstimate(lenSq);
@@ -544,7 +538,7 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         float strain = L / rest;
                         if (strain >= 1f - limitComp) continue;
                         var n = d * invLen;
-                        float rel = Vector3.Dot(velocities[j] - velocities[i], n);
+                        float rel = Vector3.Dot(velocitiesArr[j] - velocitiesArr[i], n);
                         float targetRel = +kClampComp * ((1f - limitComp) - strain) / dt;
                         float corr = (targetRel - rel);
                         float w = edge.WSum;
@@ -552,8 +546,8 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                         float lambda = corr / w;
                         var dv = lambda * n;
                         // Increase edge length rate: push j along +n, i along -n
-                        velocities[i] -= edge.Wi * dv;
-                        velocities[j] += edge.Wj * dv;
+                        velocitiesArr[i] -= edge.Wi * dv;
+                        velocitiesArr[j] += edge.Wj * dv;
                     }
                 }
             }
@@ -565,12 +559,12 @@ public sealed class VelocityImpulseSolver : IClothSimulator
                 float vCap2 = MaxVelocityMagnitude * MaxVelocityMagnitude;
                 for (int i = 0; i < _vertexCount; i++)
                 {
-                    var v = velocities[i];
+                    var v = velocitiesArr[i];
                     float s2 = v.LengthSquared();
                     if (s2 > vCap2)
                     {
                         float inv = MaxVelocityMagnitude / MathF.Sqrt(s2);
-                        velocities[i] = v * inv;
+                        velocitiesArr[i] = v * inv;
                     }
                 }
             }

--- a/src/DotCloth/Simulation/IClothSimulator.cs
+++ b/src/DotCloth/Simulation/IClothSimulator.cs
@@ -21,7 +21,7 @@ public interface IClothSimulator
     /// Advances the simulation by <paramref name="deltaTime"/>.
     /// Positions and velocities are updated in-place.
     /// </summary>
-    void Step(float deltaTime, Span<Vector3> positions, Span<Vector3> velocities);
+    void Step(float deltaTime, Vector3[] positions, Vector3[] velocities);
 
     /// <summary>Updates parameters. May re-derive internal coefficients.</summary>
     void UpdateParameters(Parameters.ClothParameters parameters);


### PR DESCRIPTION
## Summary
- drop unsafe pointer access by switching `IClothSimulator.Step` to array parameters and updating all solvers accordingly
- disable `AllowUnsafeBlocks` and document the safe parallel batching design and migration
- keep parallel constraint processing with `Parallel.For`

## Testing
- `dotnet format DotCloth.sln --verify-no-changes --verbosity diagnostic`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`
- `dotnet build -f net9.0 --property DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net9.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet build -f net8.0 --property DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net8.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet run --project perf/DotCloth.Perf -c Release --framework net9.0`
- `dotnet run --project perf/DotCloth.Perf -c Release --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68bd24ce1da8832a912506e59532b304