### PR TITLE
docs: clarify screenshots reflect experimental build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ High‑performance, UnityCloth‑compatible cloth simulation library targeting .
 ## Screenshot
 - ![MonoGame sample screenshot](docs/images/sample-monogame.png)
 - ![Godot sample screenshot](docs/images/sample-godot.png)
+- ⚠️ These captures come from an experimental build with higher throughput; the mainline solver is currently slower.
 
 ## Goals
 - UnityCloth‑compatible parameter structure and behavior alignment where practical.


### PR DESCRIPTION
## Summary
- warn that README screenshots were captured on an experimental high-throughput build

## Testing
- ⚠️ no tests run (doc-only change)


------
https://chatgpt.com/codex/tasks/task_e_68bd656241ec832aa2a028b7b2fe086b