### PR TITLE
fix(cloud-scripts): correct PATH export and maintenance update

### DIFF
--- a/.codex/cloud/maintenance.sh
+++ b/.codex/cloud/maintenance.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# update existing .NET SDK installation
+# update existing .NET SDK installations
 INSTALL_DIR="$HOME/.dotnet"
 curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir "$INSTALL_DIR" --no-cdn
+curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --install-dir "$INSTALL_DIR" --no-cdn
 "$INSTALL_DIR/dotnet" workload update || true
 
 echo "Maintenance completed."

--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -9,7 +9,7 @@ curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 -
 
 cat <<'EOP' >> "$HOME/.bashrc"
 export DOTNET_ROOT="$HOME/.dotnet"
-export PATH="\$DOTNET_ROOT:\$PATH"
+export PATH="$DOTNET_ROOT:$PATH"
 EOP
 
 echo "Done. Restart shell to use dotnet."

--- a/docs/design/codex-cloud-scripts.md
+++ b/docs/design/codex-cloud-scripts.md
@@ -6,8 +6,9 @@ Purpose
 - Trim package caches after image caching to keep layers small.
 
 Scope and Boundaries
-- Setup installs .NET SDK 9.0 and 8.0 using the official installer.
-- Maintenance removes apt package lists and cache.
+- Setup installs .NET SDK 9.0 and 8.0 using the official installer and wires `DOTNET_ROOT` into `PATH`.
+- Maintenance updates the existing .NET SDK installations.
+- Post-cache maintenance removes apt package lists and cache.
 - Scripts live under `.codex/cloud` and have no runtime dependency on library code.
 
 Dependencies


### PR DESCRIPTION
## Summary
- fix PATH export in cloud setup script to expose installed .NET SDKs
- update maintenance script to refresh both .NET 9.0 and 8.0 SDKs
- clarify design note for cloud scripts

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`
- `dotnet build -f net9.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net9.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet build -f net8.0 -p:DotClothEnableExperimentalXpbd=true`
- `dotnet test -f net8.0 -p:DotClothEnableExperimentalXpbd=true`


------
https://chatgpt.com/codex/tasks/task_e_68c19299db84832abcd650dc2aef9f5a