### PR TITLE
feat(examples): show scenario, model, and metrics in MonoGame title

### DIFF
--- a/docs/design/monogame-sample.md
+++ b/docs/design/monogame-sample.md
@@ -4,7 +4,7 @@
 Demonstrate ForceCloth with selectable scenarios and force models in an interactive desktop app.
 
 ## Scope and boundaries
-- In: basic grid cloth rendered with MonoGame; scenarios switch grid size; models toggle force combinations.
+- In: basic grid cloth rendered with MonoGame; scenarios switch grid size; models toggle force combinations; window title shows current selection and live performance metrics.
 - Out: collision geometry, advanced rendering, mobile targets.
 
 ## Public API


### PR DESCRIPTION
## Summary
- show scenario name, model name, and live performance metrics in MonoGame sample window title
- document title behaviour with performance metrics

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68c1912cd26c832ab17c730b413fcc4f