### PR TITLE
fix: respect pinned vertices in strain limiter and escape PATH export

### DIFF
--- a/.codex/cloud/setup.sh
+++ b/.codex/cloud/setup.sh
@@ -7,9 +7,9 @@ mkdir -p "$INSTALL_DIR"
 curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir "$INSTALL_DIR"
 curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0 --install-dir "$INSTALL_DIR"
 
-cat <<'EOP' >> "$HOME/.bashrc"
-export DOTNET_ROOT="$HOME/.dotnet"
-export PATH="$DOTNET_ROOT:$PATH"
+cat <<EOP >> "$HOME/.bashrc"
+export DOTNET_ROOT="\$HOME/.dotnet"
+export PATH="\$DOTNET_ROOT:\$PATH"
 EOP
 
 echo "Done. Restart shell to use dotnet."

--- a/src/DotCloth/Constraints/IConstraint.cs
+++ b/src/DotCloth/Constraints/IConstraint.cs
@@ -7,5 +7,6 @@ public interface IConstraint
 {
     /// <summary>Adjusts <paramref name="positions"/> to satisfy the constraint.</summary>
     /// <param name="positions">Particle positions in-place.</param>
-    void Project(Vector3[] positions);
+    /// <param name="invMass">Inverse masses per particle (0 for pinned).</param>
+    void Project(Vector3[] positions, float[] invMass);
 }

--- a/src/DotCloth/Constraints/StrainLimiter.cs
+++ b/src/DotCloth/Constraints/StrainLimiter.cs
@@ -36,21 +36,29 @@ public sealed class StrainLimiter : IConstraint
     }
 
     /// <inheritdoc />
-    public void Project(Vector3[] positions)
+    public void Project(Vector3[] positions, float[] invMass)
     {
         foreach (var e in _edges)
         {
-            var a = positions[e.A];
-            var b = positions[e.B];
-            var delta = b - a;
+            var a = e.A;
+            var b = e.B;
+            var w1 = invMass[a];
+            var w2 = invMass[b];
+            var wSum = w1 + w2;
+            if (wSum == 0f)
+            {
+                continue;
+            }
+
+            var delta = positions[b] - positions[a];
             var dist = delta.Length();
             var max = e.RestLength * e.MaxStretch;
             if (dist > max && dist > 1e-6f)
             {
-                var diff = 0.5f * (dist - max);
                 var dir = delta / dist;
-                positions[e.A] += diff * dir;
-                positions[e.B] -= diff * dir;
+                var diff = (dist - max) / wSum;
+                positions[a] += w1 * diff * dir;
+                positions[b] -= w2 * diff * dir;
             }
         }
     }

--- a/src/DotCloth/ForceCloth.cs
+++ b/src/DotCloth/ForceCloth.cs
@@ -72,7 +72,7 @@ public sealed class ForceCloth
 
         foreach (var c in _constraints)
         {
-            c.Project(Positions);
+            c.Project(Positions, _invMass);
         }
     }
 }

--- a/tests/DotCloth.Tests/StrainLimiterTests.cs
+++ b/tests/DotCloth.Tests/StrainLimiterTests.cs
@@ -1,0 +1,20 @@
+using System.Numerics;
+using DotCloth.Constraints;
+using Xunit;
+
+namespace DotCloth.Tests;
+
+public class StrainLimiterTests
+{
+    [Fact]
+    public void PinnedVerticesRemainFixed()
+    {
+        var positions = new[] { new Vector3(0f, 0f, 0f), new Vector3(4f, 0f, 0f) };
+        var invMass = new[] { 0f, 1f };
+        var edges = new[] { new StrainLimiter.Edge(0, 1, 2f, 1f) };
+        var limiter = new StrainLimiter(edges);
+        limiter.Project(positions, invMass);
+        Assert.Equal(new Vector3(0f, 0f, 0f), positions[0]);
+        Assert.InRange(positions[1].X, 1.99f, 2.01f);
+    }
+}


### PR DESCRIPTION
## Summary
- weight strain limiter corrections by inverse mass to keep pinned particles fixed
- add test ensuring pinned vertices remain stationary
- escape PATH export in setup script to avoid premature expansion

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68c194affd44832aa52190b5ffcdefd4