### PR TITLE
feat(godot-sample): add UI controls and metrics display

### DIFF
--- a/docs/design/godot-sample.md
+++ b/docs/design/godot-sample.md
@@ -3,14 +3,17 @@ Godot Sample – Mini Design
 
 Purpose
 - Provide a cross-platform, editor-friendly sample showcasing DotCloth integration in Godot 4 .NET.
+- Encapsulate simulation logic in a reusable `ClothNode` and expose runtime controls via a small UI panel.
 
 Scope & Boundaries
-- In: minimal Godot project that steps `ForceCloth` and allows runtime switching between force models.
-- Out: mesh deformation, editor tooling, UI, picking/drag, platform-specific code, CI build of Godot project.
+- In: minimal Godot project that steps `ForceCloth` through a dedicated node and allows runtime switching between force models and cloth size through a UI.
+- Out: mesh deformation, editor tooling, picking/drag, platform-specific code, CI build of Godot project.
 
 Public Surface
 - Folder: `examples/DotCloth.GodotSample` (not added to solution; opt-in run from Godot).
-- Main scene: `main.tscn` with `Main.cs` (`Node3D`). Model switches via number keys (1-4).
+- Main scene: `main.tscn` with root `Main.cs` (`Node3D`) wiring up cloth and UI.
+- Child node: `ClothNode.cs` (`Node3D`) exposes `Size`, `Model`, and a metrics string while stepping `ForceCloth`.
+- `ClothPanel.cs` (`Control`) hosts an option list and size spinner to switch models and resize the cloth at runtime, and a performance label showing step time, FPS, and vertex count.
 - Project file: `DotCloth.GodotSample.csproj` targeting `net8.0` with `Godot.NET.Sdk`.
 
 Placement & Dependencies

--- a/examples/DotCloth.GodotSample/ClothNode.cs
+++ b/examples/DotCloth.GodotSample/ClothNode.cs
@@ -1,0 +1,89 @@
+using System;
+using Godot;
+using DotCloth;
+using DotCloth.MonoGameSample.Scenarios;
+using System.Diagnostics;
+
+namespace DotCloth.GodotSample;
+
+public partial class ClothNode : Node3D
+{
+    [Export]
+    public int Size
+    {
+        get => _size;
+        set
+        {
+            if (_size == value)
+            {
+                return;
+            }
+            _size = value;
+            _cloth = ClothFactory.Create(_size, ToModelString(_model));
+        }
+    }
+
+    [Export]
+    public ForceModel Model
+    {
+        get => _model;
+        set
+        {
+            if (_model == value)
+            {
+                return;
+            }
+            _model = value;
+            _cloth = ClothFactory.Create(_size, ToModelString(_model));
+        }
+    }
+
+    public string ModelName => ToModelString(_model);
+
+    private ForceCloth _cloth = null!;
+    private ForceModel _model = ForceModel.Springs;
+    private int _size = 10;
+    private readonly Stopwatch _sw = new();
+    private double _perfAccum;
+    private double _fpsSmooth;
+
+    public string Metrics { get; private set; } = string.Empty;
+
+    public override void _Ready()
+    {
+        _cloth = ClothFactory.Create(_size, ToModelString(_model));
+    }
+
+    public override void _PhysicsProcess(double delta)
+    {
+        _sw.Restart();
+        _cloth.Step((float)delta);
+        var simMs = _sw.Elapsed.TotalMilliseconds;
+
+        _perfAccum += delta;
+        if (_perfAccum >= 0.25)
+        {
+            _perfAccum = 0.0;
+            var fps = Engine.GetFramesPerSecond();
+            _fpsSmooth = _fpsSmooth <= 0 ? fps : (_fpsSmooth * 0.9 + fps * 0.1);
+            Metrics = $"Perf: Sim {simMs:F2} ms | FPS {(float)_fpsSmooth:F1} | Verts {_cloth.Positions.Length}";
+        }
+    }
+
+    private static string ToModelString(ForceModel model) => model switch
+    {
+        ForceModel.Springs => "Springs",
+        ForceModel.Shells => "Shells",
+        ForceModel.Fem => "FEM",
+        ForceModel.SpringsWithStrain => "Springs+Strain",
+        _ => throw new ArgumentOutOfRangeException(nameof(model), model, null)
+    };
+}
+
+public enum ForceModel
+{
+    Springs,
+    Shells,
+    Fem,
+    SpringsWithStrain
+}

--- a/examples/DotCloth.GodotSample/ClothPanel.cs
+++ b/examples/DotCloth.GodotSample/ClothPanel.cs
@@ -1,0 +1,50 @@
+using System;
+using Godot;
+
+namespace DotCloth.GodotSample;
+
+public partial class ClothPanel : Control
+{
+    [Export]
+    public NodePath ClothPath { get; set; } = null!;
+
+    private ClothNode _cloth = null!;
+    private OptionButton _modelOption = null!;
+    private SpinBox _sizeInput = null!;
+    private Label _perfLabel = null!;
+
+    public override void _Ready()
+    {
+        _cloth = GetNode<ClothNode>(ClothPath);
+        _modelOption = GetNode<OptionButton>("VBoxContainer/ModelOption");
+        _sizeInput = GetNode<SpinBox>("VBoxContainer/SizeInput");
+        _perfLabel = GetNode<Label>("VBoxContainer/PerfLabel");
+
+        foreach (ForceModel model in Enum.GetValues<ForceModel>())
+        {
+            _modelOption.AddItem(model.ToString(), (int)model);
+        }
+
+        _modelOption.Selected = (int)_cloth.Model;
+        _sizeInput.Value = _cloth.Size;
+
+        _modelOption.ItemSelected += OnModelSelected;
+        _sizeInput.ValueChanged += OnSizeChanged;
+    }
+
+    public override void _Process(double delta)
+    {
+        _perfLabel.Text = _cloth.Metrics;
+    }
+
+    private void OnModelSelected(long index)
+    {
+        _cloth.Model = (ForceModel)index;
+    }
+
+    private void OnSizeChanged(double value)
+    {
+        _cloth.Size = (int)value;
+    }
+}
+

--- a/examples/DotCloth.GodotSample/Directory.Build.props
+++ b/examples/DotCloth.GodotSample/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <GodotProjectDir>$(MSBuildThisFileDirectory)</GodotProjectDir>
+  </PropertyGroup>
+</Project>
+

--- a/examples/DotCloth.GodotSample/DotCloth.GodotSample.csproj
+++ b/examples/DotCloth.GodotSample/DotCloth.GodotSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Godot.NET.Sdk/4.2.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <GodotProjectDir>.</GodotProjectDir>
+    <GodotProjectDir>$(MSBuildProjectDirectory)</GodotProjectDir>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../DotCloth.MonoGameSample/Scenarios/ClothFactory.cs" Link="ClothFactory.cs" />

--- a/examples/DotCloth.GodotSample/Main.cs
+++ b/examples/DotCloth.GodotSample/Main.cs
@@ -1,44 +1,14 @@
 using Godot;
-using DotCloth;
-using DotCloth.MonoGameSample.Scenarios;
 
 namespace DotCloth.GodotSample;
 
 public partial class Main : Node3D
 {
-    private ForceCloth _cloth = null!;
-    private int _size = 10;
-    private string _model = "Springs";
+    private ClothNode _cloth = null!;
 
     public override void _Ready()
     {
-        _cloth = ClothFactory.Create(_size, _model);
-        GD.Print($"Model: {_model}");
-    }
-
-    public override void _PhysicsProcess(double delta)
-    {
-        _cloth.Step((float)delta);
-    }
-
-    public override void _Input(InputEvent @event)
-    {
-        if (@event is InputEventKey { Pressed: true } key)
-        {
-            string? next = key.Keycode switch
-            {
-                Key.Key1 => "Springs",
-                Key.Key2 => "Shells",
-                Key.Key3 => "FEM",
-                Key.Key4 => "Springs+Strain",
-                _ => null
-            };
-            if (next is not null && next != _model)
-            {
-                _model = next;
-                _cloth = ClothFactory.Create(_size, _model);
-                GD.Print($"Model: {_model}");
-            }
-        }
+        _cloth = GetNode<ClothNode>("Cloth");
+        GD.Print($"Model: {_cloth.ModelName} Size: {_cloth.Size}");
     }
 }

--- a/examples/DotCloth.GodotSample/README.md
+++ b/examples/DotCloth.GodotSample/README.md
@@ -1,6 +1,4 @@
 # DotCloth Godot Sample
 
 Minimal Godot 4 project using DotCloth.
-
-## Model switching
-Press **1** for springs, **2** for shells, **3** for FEM, **4** for springs with strain limiter.
+The scene contains a `Main` root node, a child `Cloth` node that wraps the simulation, and a `ClothPanel` control for runtime model and size changes with a performance readout.

--- a/examples/DotCloth.GodotSample/main.tscn
+++ b/examples/DotCloth.GodotSample/main.tscn
@@ -1,6 +1,31 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource path="res://Main.cs" type="Script" id=1]
+[ext_resource path="res://ClothNode.cs" type="Script" id=2]
+[ext_resource path="res://ClothPanel.cs" type="Script" id=3]
 
 [node name="Main" type="Node3D"]
 script = ExtResource(1)
+
+[node name="Cloth" type="Node3D" parent="."]
+script = ExtResource(2)
+
+[node name="ClothPanel" type="Control" parent="."]
+layout_mode = 3
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource(3)
+ClothPath = NodePath("../Cloth")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ClothPanel"]
+offset_left = 8.0
+offset_top = 8.0
+
+[node name="ModelOption" type="OptionButton" parent="ClothPanel/VBoxContainer"]
+
+[node name="SizeInput" type="SpinBox" parent="ClothPanel/VBoxContainer"]
+min_value = 2.0
+max_value = 20.0
+step = 1.0
+
+[node name="PerfLabel" type="Label" parent="ClothPanel/VBoxContainer"]


### PR DESCRIPTION
## Summary
- add ClothPanel control to switch force model and cloth size at runtime
- expose performance metrics from ClothNode and display them through a PerfLabel
- fix Godot sample build by providing GodotProjectDir in Directory.Build.props

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`
- `dotnet build examples/DotCloth.GodotSample/DotCloth.GodotSample.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c19231991c832aaf0cb0848bcebbbf