### PR TITLE
feat(core): add particle pinning API

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -13,3 +13,7 @@ Parameter Mapping
 | Mass                  | 1 / invMass               |
 
 Additional parameters such as friction or wind can be layered on later via new force models or colliders.
+
+Particle Pinning
+-----------------
+Fix particles in place with `Pin(index, position)` and restore motion with `Unpin(index, invMass)`.

--- a/docs/design/pin-methods.md
+++ b/docs/design/pin-methods.md
@@ -1,0 +1,30 @@
+Pin Methods Design Note
+=======================
+
+Purpose
+-------
+Provide explicit APIs to fix or release cloth particles without manual inverse mass edits.
+
+Public API
+----------
+- `ForceCloth.Pin(int index, Vector3 position)`
+- `ForceCloth.Unpin(int index, float invMass)`
+- `MassSpringCloth.Pin(int index, Vector3 position)`
+- `MassSpringCloth.Unpin(int index, float invMass)`
+
+Boundaries
+----------
+- Pins zero the inverse mass and velocity; callers may move pinned particles by writing to `Positions`.
+- No `MaxDistance` or soft tether behavior is added.
+
+Dependencies
+------------
+No new dependencies; operates on existing arrays.
+
+Testing
+-------
+Unit tests pin a particle, verify it remains fixed, then unpin and confirm it moves under gravity.
+
+Migration
+---------
+Additive API; existing code continues to work without changes.

--- a/src/DotCloth/ForceCloth.cs
+++ b/src/DotCloth/ForceCloth.cs
@@ -44,6 +44,22 @@ public sealed class ForceCloth
     /// <summary>Current particle positions.</summary>
     public Vector3[] Positions { get; }
 
+    /// <summary>Pins the particle at <paramref name="index"/> to <paramref name="position"/>.</summary>
+    public void Pin(int index, Vector3 position)
+    {
+        _invMass[index] = 0f;
+        _velocities[index] = Vector3.Zero;
+        Positions[index] = position;
+    }
+
+    /// <summary>Restores movement of the particle at <paramref name="index"/>.</summary>
+    /// <param name="index">Particle to unpin.</param>
+    /// <param name="invMass">Inverse mass to apply after unpinning.</param>
+    public void Unpin(int index, float invMass)
+    {
+        _invMass[index] = invMass;
+    }
+
     /// <summary>Advances the simulation by <paramref name="dt"/> seconds.</summary>
     public void Step(float dt)
     {

--- a/src/DotCloth/MassSpring/MassSpringCloth.cs
+++ b/src/DotCloth/MassSpring/MassSpringCloth.cs
@@ -60,6 +60,22 @@ public sealed class MassSpringCloth
     /// <summary>Current particle positions.</summary>
     public Vector3[] Positions { get; }
 
+    /// <summary>Pins the particle at <paramref name="index"/> to <paramref name="position"/>.</summary>
+    public void Pin(int index, Vector3 position)
+    {
+        _invMass[index] = 0f;
+        _velocities[index] = Vector3.Zero;
+        Positions[index] = position;
+    }
+
+    /// <summary>Restores movement of the particle at <paramref name="index"/>.</summary>
+    /// <param name="index">Particle to unpin.</param>
+    /// <param name="invMass">Inverse mass to apply after unpinning.</param>
+    public void Unpin(int index, float invMass)
+    {
+        _invMass[index] = invMass;
+    }
+
     /// <summary>
     /// Advances the simulation by <paramref name="dt"/> seconds.
     /// </summary>

--- a/tests/DotCloth.Tests/ForceClothTests.cs
+++ b/tests/DotCloth.Tests/ForceClothTests.cs
@@ -29,11 +29,13 @@ public class ForceClothTests
     private static ForceCloth CreateSpringCloth(IIntegrator integrator)
     {
         var positions = new[] { new Vector3(0f, 2f, 0f), new Vector3(0f, 1f, 0f) };
-        var invMass = new[] { 0f, 1f };
+        var invMass = new[] { 1f, 1f };
         var springs = new EdgeSpringForce.Spring[] { new(0, 1, 1f, 100f) };
         var forces = new IForce[] { new EdgeSpringForce(springs) };
         var colliders = new ICollider[] { new PlaneCollider(Vector3.Zero, Vector3.UnitY) };
-        return new ForceCloth(positions, invMass, forces, new Vector3(0f, -9.81f, 0f), 0.98f, integrator: integrator, colliders: colliders);
+        var cloth = new ForceCloth(positions, invMass, forces, new Vector3(0f, -9.81f, 0f), 0.98f, integrator: integrator, colliders: colliders);
+        cloth.Pin(0, positions[0]);
+        return cloth;
     }
 
     private static ForceCloth CreateShellCloth(IIntegrator integrator)
@@ -45,7 +47,7 @@ public class ForceClothTests
             new Vector3(0f, 0f, 0f),
             new Vector3(1f, 0f, 0f)
         };
-        var invMass = new[] { 0f, 1f, 1f, 1f };
+        var invMass = new[] { 1f, 1f, 1f, 1f };
         var springs = new EdgeSpringForce.Spring[]
         {
             new(0,1,1f,50f), new(1,3,1f,50f), new(3,2,1f,50f), new(2,0,1f,50f),
@@ -54,7 +56,9 @@ public class ForceClothTests
         var dihedrals = new DiscreteShellForce.Dihedral[] { new(0, 1, 3, 2, 0f, 10f) };
         var forces = new IForce[] { new EdgeSpringForce(springs), new DiscreteShellForce(dihedrals) };
         var colliders = new ICollider[] { new PlaneCollider(Vector3.Zero, Vector3.UnitY) };
-        return new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, integrator: integrator, colliders: colliders);
+        var cloth = new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, integrator: integrator, colliders: colliders);
+        cloth.Pin(0, positions[0]);
+        return cloth;
     }
 
     private static ForceCloth CreateFemCloth(IIntegrator integrator)
@@ -65,23 +69,27 @@ public class ForceClothTests
             new Vector3(1f, 1f, 0f),
             new Vector3(0f, 0f, 0f)
         };
-        var invMass = new[] { 0f, 1f, 1f };
+        var invMass = new[] { 1f, 1f, 1f };
         var tris = new CoRotationalFemForce.Triangle[] { new(0, 1, 2, positions[0], positions[1], positions[2], 10f) };
         var forces = new IForce[] { new CoRotationalFemForce(tris) };
         var colliders = new ICollider[] { new PlaneCollider(Vector3.Zero, Vector3.UnitY) };
-        return new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, integrator: integrator, colliders: colliders);
+        var cloth = new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, integrator: integrator, colliders: colliders);
+        cloth.Pin(0, positions[0]);
+        return cloth;
     }
 
     private static ForceCloth CreateStrainCloth(IIntegrator integrator)
     {
         var positions = new[] { new Vector3(0f, 2f, 0f), new Vector3(0f, 1f, 0f) };
-        var invMass = new[] { 0f, 1f };
+        var invMass = new[] { 1f, 1f };
         var springs = new EdgeSpringForce.Spring[] { new(0, 1, 1f, 500f) };
         var forces = new IForce[] { new EdgeSpringForce(springs) };
         var edges = new StrainLimiter.Edge[] { new(0, 1, 1f, 1.1f) };
         var limiter = new StrainLimiter(edges);
         var colliders = new ICollider[] { new PlaneCollider(Vector3.Zero, Vector3.UnitY) };
-        return new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, new IConstraint[] { limiter }, integrator, colliders);
+        var cloth = new ForceCloth(positions, invMass, forces, Vector3.Zero, 0.99f, new IConstraint[] { limiter }, integrator, colliders);
+        cloth.Pin(0, positions[0]);
+        return cloth;
     }
 
     [Theory]

--- a/tests/DotCloth.Tests/PinTests.cs
+++ b/tests/DotCloth.Tests/PinTests.cs
@@ -1,0 +1,48 @@
+using System.Numerics;
+using DotCloth;
+using DotCloth.Forces;
+using DotCloth.MassSpring;
+using Xunit;
+
+namespace DotCloth.Tests;
+
+public class PinTests
+{
+    [Fact]
+    public void ForceCloth_PinnedParticle_RemainsFixed()
+    {
+        var positions = new[] { new Vector3(0f, 1f, 0f), new Vector3(0f, 0f, 0f) };
+        var invMass = new[] { 1f, 1f };
+        var cloth = new ForceCloth(positions, invMass, Array.Empty<IForce>(), new Vector3(0f, -9.81f, 0f), 0.99f);
+        cloth.Pin(0, positions[0]);
+        cloth.Step(0.016f);
+        Assert.Equal(1f, cloth.Positions[0].Y, 5);
+        Assert.True(cloth.Positions[1].Y < cloth.Positions[0].Y);
+    }
+
+    [Fact]
+    public void MassSpringCloth_PinnedParticle_RemainsFixed()
+    {
+        var positions = new[] { new Vector3(0f, 1f, 0f), new Vector3(0f, 0f, 0f) };
+        var invMass = new[] { 1f, 1f };
+        var springs = new MassSpringCloth.Spring[] { new(0, 1, 1f, 10f) };
+        var cloth = new MassSpringCloth(positions, invMass, springs, new Vector3(0f, -9.81f, 0f), 0.99f);
+        cloth.Pin(0, positions[0]);
+        cloth.Step(0.016f);
+        Assert.Equal(1f, cloth.Positions[0].Y, 5);
+        Assert.True(cloth.Positions[1].Y < cloth.Positions[0].Y);
+    }
+
+    [Fact]
+    public void ForceCloth_Unpin_AllowsMotion()
+    {
+        var positions = new[] { new Vector3(0f, 1f, 0f) };
+        var invMass = new[] { 1f };
+        var cloth = new ForceCloth(positions, invMass, Array.Empty<IForce>(), new Vector3(0f, -9.81f, 0f), 0.99f);
+        cloth.Pin(0, positions[0]);
+        cloth.Step(0.016f);
+        cloth.Unpin(0, 1f);
+        cloth.Step(0.016f);
+        Assert.True(cloth.Positions[0].Y < 1f);
+    }
+}


### PR DESCRIPTION
## Summary
- add Pin/Unpin methods to cloth solvers
- document new pinning API
- cover pinning behavior with unit tests
- pin particles via API in solver regression tests

## Testing
- `dotnet format --verify-no-changes`
- `dotnet build -f net9.0`
- `dotnet test -f net9.0`
- `dotnet build -f net8.0`
- `dotnet test -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68c1a97e3e18832a86d6c9791c2c2ae3